### PR TITLE
Add SaShiMi project as a submodule (Group 01)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SaShiMi"]
+	path = SaShiMi
+	url = https://github.com/necrashter/SaShiMi-796.git

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 METU CENG796 Deep Generative Models 2023-Spring Course Projects
 
 ## Spring 2023 projects
+* [SaShiMi](https://github.com/necrashter/SaShiMi-796) - It's Raw! Audio Generation with State-Space Models (ICML'22)
 * [MVCGAN](MVCGAN/) - Multi-View Consistent Generative Adversarial Networks for 3D-aware Image Synthesis (CVPR'22)


### PR DESCRIPTION
As you briefly mentioned in the lecture today, I added our project as a [submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules), which is the standard way of including git repositories inside other git repositories. I've also added the project to the list in `README.md` file.

Thank you for the course! It was the most challenging but also the most enjoyable course project I've done.